### PR TITLE
Fix codacy issues and coverage reporting

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,2 +1,4 @@
 exclude_paths:
-  - '/test/**/*'
+  - "CODE_OF_CONDUCT.md"
+  - "LICENSE"
+  - ".github/**/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ jdk:
 
 # Run before every job
 before_install:
-  #- sudo apt-get update
-  #- sudo apt-get install -y openjdk-8-jdk
-  #- PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
-  #- sudo apt-get install -y openjfx
   - java -version
   - uname -a
   - chmod +x pom.xml
@@ -33,5 +29,5 @@ jobs:
       # Generating test coverage report and publishing to Codacy
       script:
         - mvn clean test jacoco:report
-        - curl -Ls -o codacy-coverage-reporter-assembly.jar https://github.com/codacy/codacy-coverage-reporter/releases/download/6.0.2/codacy-coverage-reporter-6.0.2-assembly.jar
+        - curl -Ls -o codacy-coverage-reporter-assembly.jar https://github.com/codacy/codacy-coverage-reporter/releases/download/12.2.0/codacy-coverage-reporter-assembly.jar
         - java -jar codacy-coverage-reporter-assembly.jar report -l Java -r target/site/jacoco/jacoco.xml

--- a/src/main/java/com/github/extractor/App.java
+++ b/src/main/java/com/github/extractor/App.java
@@ -11,7 +11,6 @@ public class App {
         try {
             final JsonObject cliOptions = Cli.parseArgs(args);
             final Configuration config = ConfigFactory.createFromInputArgs(cliOptions);
-            System.out.println("Class in file: " + String.valueOf(new Executor(config)));
             new Executor(config).run();
         } catch (final HelpGivenException e) {
             System.out.println(e.getMessage());

--- a/src/main/java/com/github/extractor/Executor.java
+++ b/src/main/java/com/github/extractor/Executor.java
@@ -22,7 +22,6 @@ public class Executor {
 
     public Executor(final Configuration config) {
         this.config = config;
-        System.out.println(config.toString());
     }
 
     public void run() {


### PR DESCRIPTION
- Codacy coverage reporting is broken, this commit updates
  codacy coverage reporter tool to latest version.
- Ignore some standard github files from codacy scans.
- Remove automatic config prints at execution.